### PR TITLE
Bumping websocket min version to 14.2 where Server export was introduced

### DIFF
--- a/pipecat/pyproject.toml
+++ b/pipecat/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "loguru~=0.7.3",
     "pipecat-ai>=0.0.81",
-    "websockets>=13.1,<15.0",
+    "websockets>=14.2,<15.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

### Description

This PR fixes an import issue in `observer.py:39`. The `Server` import appears to have only been introduced in **websockets >= 14.2**. With **websockets 14.1** or earlier, the import fails.

* In 14.2, `Server` is exposed in [__init__.py](https://github.com/python-websockets/websockets/blob/14.2/src/websockets/__init__.py)
* In 14.1, it is not available [__init__.py](https://github.com/python-websockets/websockets/blob/14.1/src/websockets/__init__.py)
* In 13.1, it is not available [__init__.py](https://github.com/python-websockets/websockets/blob/13.1/src/websockets/__init__.py)

### Steps to Reproduce

1. Install **websockets 13.1**
2. Run with **pipecat v0.0.81**
3. Observe the import error in `observer.py`

