### PR TITLE
Bump websocket version to <16.0, following what pipecat-ai supports

### DIFF
--- a/pipecat/pyproject.toml
+++ b/pipecat/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "loguru>=0.7.3,<1",
     "msgpack>=1.1.1,<2",
     "pipecat-ai>=0.0.81",
-    "websockets>=13.1,<15.0",
+    "websockets>=13.1,<16.0",
 ]
 
 [project.urls]

--- a/pipecat/uv.lock
+++ b/pipecat/uv.lock
@@ -1242,7 +1242,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3,<1" },
     { name = "msgpack", specifier = ">=1.1.1,<2" },
     { name = "pipecat-ai", specifier = ">=0.0.81" },
-    { name = "websockets", specifier = ">=13.1,<15.0" },
+    { name = "websockets", specifier = ">=13.1,<16.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Bump the websocket version to <16.0, following what pipecat-ai defines: https://github.com/pipecat-ai/pipecat/blob/8f04f894d5aa2ac7ea623131b004dea956dd8904/pyproject.toml#L126