### PR TITLE
fix: resolve postcss XSS vulnerability

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3092,9 +3092,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary

- Resolves the postcss XSS vulnerability ([GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93), moderate severity, unescaped `</style>` in CSS stringify output) by updating postcss to >=8.5.10.
- Applied via `npm audit fix` in `ui/`. Only `ui/package-lock.json` changes; no breaking changes.
- `npm audit` now reports 0 vulnerabilities for `ui/`.

## Test plan

- [x] CI passes
- [x] `ui/` builds locally (`npm run build`)