### PR TITLE
fix: patch ws security vulnerability in ui

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3902,9 +3902,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary
- Updates ws to >8.20.0 in ui/ to fix moderate uninitialized memory disclosure vulnerability (GHSA-58qx-3vcg-4xpx)

## Test plan
- [x] Verify `npm audit` shows 0 vulnerabilities in ui/
- [x] Verify build passes