### PR TITLE
fix: update idna to 3.16 for CVE DoS vulnerability

### DIFF
--- a/pipecat/pyproject.toml
+++ b/pipecat/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "aiofiles>=24.1.0,<25",
+    "idna>=3.15",
     "loguru>=0.7.3,<1",
     "msgpack>=1.1.1,<2",
     "pipecat-ai>=1.0.0",

--- a/pipecat/uv.lock
+++ b/pipecat/uv.lock
@@ -546,11 +546,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Updates `idna` from 3.11 to 3.16 to fix [GHSA-65pc-fj4g-8rjx](https://github.com/kjd/idna/security/advisories/GHSA-65pc-fj4g-8rjx) (MODERATE severity DoS vulnerability)
- Adds explicit `idna>=3.15` constraint to `pyproject.toml` to prevent regression
- Updates `uv.lock` with new hashes from PyPI

## Vulnerability Details

`idna` versions prior to 3.15 are vulnerable to denial of service via specially crafted inputs to `idna.encode()`. Payloads such as `"٠" * N` or `"・" * N + "漢"` exploit the `valid_contexto` function before length rejection, causing excessive processing time for large values of N.

This is a transitive runtime dependency used by httpx, anyio, aiohttp, and yarl.

## Additional Notes

**npm audit (ui/)**: 0 vulnerabilities found.

**Python (pipecat/) dev dependency**: `pip` 26.0.1 also has two MODERATE advisories (GHSA-58qw-9mgm-455v, GHSA-jp4c-xjxw-mgf9) patched in 26.1. This is a dev-only dependency (via pip-tools) and was not updated in this PR. A separate update of `pip-tools` would pull in the fix.

## Test plan

- [x] Verify `uv lock --check` passes (confirms lock file consistency)
- [x] Verify `uv sync` installs idna 3.16 successfully
- [x] Run existing test suite to confirm no regressions