### PR TITLE
Fix security vulnerabilities in UI dependencies

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2999,9 +2999,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -3092,9 +3092,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3111,7 +3111,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Summary
Fixes 2 high-severity vulnerabilities flagged by `npm audit` in the UI package:
- nanoid <=3.3.16: non-secure generators can loop indefinitely (GHSA-28wg-ghj8-5hjv, GHSA-2v37-7h3g-55p8)
- postcss <=8.5.22: path traversal in sourcemap auto-loading, arbitrary .map file disclosure (GHSA-r28c-9q8g-f849, GHSA-fxqj-rqcc-2cmp)

Both are transitive dependencies bumped via `npm audit fix` (nanoid 3.3.12 -> 3.3.18, postcss 8.5.15 -> 8.5.26). No direct dependency version changes or code changes required.

Also checked the pipecat (Python) sub-project with `pip-audit` against the synced `uv.lock` environment: no known vulnerabilities found there, so no changes were needed on that side.

## Test plan
- `cd ui && npm audit` now reports 0 vulnerabilities
- `cd pipecat && uv run --with pip-audit pip-audit --local` reports no known vulnerabilities