### PR TITLE
Fix deprecation warnings from the frame serializer

### DIFF
--- a/changelog/31.fixed.md
+++ b/changelog/31.fixed.md
@@ -1,0 +1,1 @@
+- Fixed deprecation warnings being emitted for every frame sent to Whisker. Deprecated frame fields, such as `StartFrame.audio_in_sample_rate` and its siblings, warn when read, and the serializer read each dataclass field twice while walking every frame. It now reads the raw instance state instead, so no warning is emitted.

--- a/pipecat/src/pipecat_whisker/sink.py
+++ b/pipecat/src/pipecat_whisker/sink.py
@@ -166,12 +166,11 @@ def whisker_obj_serializer(obj: Any) -> Any:
     Returns:
         A JSON-shaped representation of the input.
     """
-    if is_dataclass(obj):
-        return {
-            f.name: whisker_obj_serializer(getattr(obj, f.name))
-            for f in fields(obj)
-            if getattr(obj, f.name) is not None
-        }
+    if is_dataclass(obj) and not isinstance(obj, type):
+        # Read the raw instance state: a field can intercept reads to warn that
+        # it is deprecated, and this walks every field of every frame.
+        values = {f.name: object.__getattribute__(obj, f.name) for f in fields(obj)}
+        return {k: whisker_obj_serializer(v) for k, v in values.items() if v is not None}
     elif isinstance(obj, (list, tuple, set)):
         return [whisker_obj_serializer(v) for v in obj if v is not None]
     elif isinstance(obj, dict):

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,1 +1,2 @@
 .vercel
+.env*


### PR DESCRIPTION
## Summary

Every frame observed by Whisker emitted a burst of `DeprecationWarning`s — a dozen per `StartFrame`, repeated at each processor hop, unbounded and unsuppressable.

Two causes combined:

- Pipecat's `StartFrame` intercepts reads of its migrated configuration fields (`audio_in_sample_rate` and six siblings) and warns on each read.
- `whisker_obj_serializer` walks every dataclass field of every frame, and read each field **twice** — once to test it for `None`, once for its value.

The serializer now builds the field map in one pass, from raw instance state:

```python
values = {f.name: object.__getattribute__(obj, f.name) for f in fields(obj)}
return {k: whisker_obj_serializer(v) for k, v in values.items() if v is not None}
```

`object.__getattribute__` returns the same value while bypassing the interception, so serialized payloads are unchanged. A debug tool *rendering* a field shouldn't trip a notice aimed at callers *using* it.

Suppressing the warnings instead does not work: Pipecat raises them inside its own `catch_warnings()` + `simplefilter("always")`, which replaces the caller's filters for the duration of the call — a `simplefilter("ignore")` around serialization has no effect. The read has to be avoided, not silenced.

Also here:

- Guarded the dataclass branch with `not isinstance(obj, type)`. `is_dataclass()` is true for dataclass *classes* as well as instances, and `object.__getattribute__` doesn't behave like `getattr` on a class. Such a value now serializes as `<type: type>` rather than its class-level defaults; no frame field is known to hold one.
- Unrelated: added `.env*` to `ui/.gitignore`.

## Related Pipecat change

This clears the warnings for anyone running both packages. A companion Pipecat change makes the deprecation warn once per call site instead of on every read, which bounds the same flood for users on older Whisker versions and for any other caller that reflects over frame fields. Not required by this PR.

## Test plan

Whisker has no test suite, so `whisker_obj_serializer` was exercised directly:

- 50 `StartFrame`s serialized against a Pipecat build carrying the deprecation shim: 0 warnings, against 600 before the change.
- `StartFrame` and `TextFrame` payloads compared before and after: identical.
- `uv run ruff check src/` and `uv run ruff format --check src/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
